### PR TITLE
Include base tree

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -459,6 +459,7 @@ async function merge(options){
             owner
             ,repo
             ,tree: changes
+            ,base_tree
         })
 
         let commit = await octokit.rest.git.createCommit({


### PR DESCRIPTION
Without base_tree main ends up having only the files included in the tree update, it deletes everything else.