### PR TITLE
Refresh source branch on merge

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,16 @@
         {
             "type": "pwa-node",
             "request": "launch",
+            "name": "recreateSourceBranch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "args": ["recreateSourceBranch"],
+            "program": "${workspaceFolder}/lib/index.js"
+        },
+        {
+            "type": "pwa-node",
+            "request": "launch",
             "name": "pr",
             "skipFiles": [
                 "<node_internals>/**"

--- a/lib/index.js
+++ b/lib/index.js
@@ -495,6 +495,12 @@ async function merge(options){
         // ,draft
         // ,prerelease
     });
+
+    if( options.refresh || options.refreshClean ){
+        await recreateSourceBranch({
+            ...options, clean: !!options.refreshClean
+        })
+    }
 }
 
 async function inferVersion({ owner, repo, lastRelease }){
@@ -876,9 +882,9 @@ async function recreateSourceBranch(options){
         owner, repo, ref: `heads/${target}`
     })
     let sourceSha = x.data.object.sha
-    // create new branch based off ${target} named `${target}-candidate-${iso}`
-    let candidateName = `${target}-candidate-${new Date().toISOString()}`
-    let archiveName = `${target}-archive-${new Date().toISOString()}`
+    // create new branch based off ${target} named `${source}-candidate-${iso}`
+    let candidateName = `${source}-candidate-${new Date().getTime()}`
+    let archiveName = `${source}-archive-${new Date().getTime()}`
 
     await octokit.rest.git.createRef({
         owner, repo, ref: `refs/heads/${candidateName}`, sha: sourceSha
@@ -895,10 +901,26 @@ async function recreateSourceBranch(options){
     // should happen automatically because it is pattern based
         // migrate protected rules, settings, patterns
 
+    // update repo default branch
+    await octokit.rest.repos.update({
+        owner, repo, default_branch: 'next'
+    })
+
     // check if this happens automatically
         // update all open PRs targeting old ${source} to target new ${source}
 
-    if (options.clean) {
+    let prs = 
+        await octokit.paginate(octokit.rest.search.issuesAndPullRequests, {
+            q: `is:pr is:open base:${source} repo:${owner}/${repo}`
+        })
+
+    for( let pr of prs ) {
+        await octokit.rest.pulls.update({
+            owner, repo, pull_number: pr.number, base: 'next'
+        })
+    }
+
+    if (true || options.clean) {
         // delete archive branch
         await octokit.rest.git.deleteRef({
             owner, repo, ref: `heads/${archiveName}`
@@ -942,11 +964,11 @@ subcommands:
 
   {blue global flags}
 
-    {blue --source <branch>}           
+    {blue --source <branch>}
 
                         (default=next) Specify the branch that is considered the staging branch.
 
-    {blue --target <branch>}           
+    {blue --target <branch>}
 
                         (default=main) Specify the branch that is considered the production branch.
 
@@ -958,6 +980,15 @@ subcommands:
 
                         Commits updated changelog and creates new npm/github/etc release.
                         Should run on every relevant merge event.
+
+    {blue --refresh} 
+    {blue --refresh-clean}
+
+                        Recreate the source branch from the current target branch ref.
+                        Automatically migrates open PRs, and updates the default branch on the repository.
+
+                        {blue --refresh-clean} will also delete the old source branch while {blue --refresh}
+                        will simply rename it as <source>-archive-<timestamp>
 
   {magenta actions-yml}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -870,6 +870,42 @@ async function pr(){
     }
 }
 
+async function recreateSourceBranch(options){
+    let [owner,repo] = process.env.GITHUB_REPOSITORY.split('/')
+    let x = await octokit.rest.git.getRef({
+        owner, repo, ref: `heads/${target}`
+    })
+    let sourceSha = x.data.object.sha
+    // create new branch based off ${target} named `${target}-candidate-${iso}`
+    let candidateName = `${target}-candidate-${new Date().toISOString()}`
+    let archiveName = `${target}-archive-${new Date().toISOString()}`
+
+    await octokit.rest.git.createRef({
+        owner, repo, ref: `refs/heads/${candidateName}`, sha: sourceSha
+    })
+
+    await octokit.rest.repos.renameBranch({
+        owner, repo, branch: 'next', new_name: archiveName
+    })
+
+    await octokit.rest.repos.renameBranch({
+        owner, repo, branch: candidateName, new_name: 'next'
+    })
+
+    // should happen automatically because it is pattern based
+        // migrate protected rules, settings, patterns
+
+    // check if this happens automatically
+        // update all open PRs targeting old ${source} to target new ${source}
+
+    if (options.clean) {
+        // delete archive branch
+        await octokit.rest.git.deleteRef({
+            owner, repo, ref: `heads/${archiveName}`
+        })
+    }
+}
+
 async function changelog(options){
     let x = await extractChangelog({})
 
@@ -936,6 +972,7 @@ let subcommands = {
     , 'actions-yml': actionsYML
     , 'extract-changelog': extractChangelog
     , changelog
+    , recreateSourceBranch
 }
 
 let preflights = {
@@ -943,6 +980,7 @@ let preflights = {
     , merge
     , 'extract-changelog': extractChangelog
     , changelog
+    , recreateSourceBranch
 }
 
 


### PR DESCRIPTION
## What

Creates a new release candidate branch every release and archives the old one.  The new candidate is simply a new ref pointing to the same `sha` as the target branch.  This means any build artifacts that are generated at release time on the `target` branch will also appear in the `source` branch.

## Why

As the target branch is meant to represent production / a live release, it makes sense that our release candidate source should have all changes available in that target branch.  Additionally, as the source branch is designed to the default branch of the repo, this change will prevent people from getting too confused by seeing missing changes, wrong version, outdated changelogs etc when landing on the repository front page.  


Fixes #51 