### PR TITLE
Include untracked files in release commit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -456,17 +456,14 @@ async function merge(options){
         // outside of normal pr-release usage
         let changes = await $`git diff --quiet`.exitCode
 
-        verbose('Git diff exit code', changes)
+        let untracked = (await $`git ls-files --others --exclude-standard`)
+            .stdout.trim().split('\n').filter(Boolean)
 
-        verbose(await $`git log --oneline | head`)
-        verbose(await $`cat changelog.md`)
-        verbose(await $`git status`)
-
-        if( changes !== 0 ) break commit;
+        if( untracked.length == 0 && changes !== 0 ) break commit;
 
         changes = await $`git diff --name-only`
         changes = `${changes}`.trim()
-        changes = changes.split('\n')
+        changes = [...new Set(changes.split('\n').concat(untracked))]
 
         changes = changes.map( async x => {
             let content = await fs.readFile(x)


### PR DESCRIPTION
Changelog et al weren't included because `git diff --name-only` doesn't include untracked files.