### PR TITLE
Update source ref instead of creating source

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -503,6 +503,10 @@ async function merge(options){
         await octokit.rest.git.updateRef({
             owner, repo, ref: `heads/${target}`, sha
         })
+
+        await octokit.rest.git.updateRef({
+            owner, repo, ref: `heads/${source}`, sha
+        })
     }
 
     // Create the tag
@@ -523,11 +527,11 @@ async function merge(options){
         // ,prerelease
     });
 
-    if( options.refresh || options['refresh-clean'] ){
-        await recreateSourceBranch({
-            ...options, clean: !!options['refresh-clean']
-        })
-    }
+    // if( options.refresh || options['refresh-clean'] ){
+    //     await recreateSourceBranch({
+    //         ...options, clean: !!options['refresh-clean']
+    //     })
+    // }
 }
 
 async function inferVersion({ owner, repo, lastRelease }){


### PR DESCRIPTION
There is currently a fn `recreateSourceBranch`.  It ensures `next` is always in sync with `main` by recreating `next` post merge from `main`.

I think an easier approach is to just call `updateRef` and make `next` point to the same sha as `main`.

A branch is just a name for a ref, so if I just say "this name" points to the same sha as `main` the are in sync.  And I won't need to do any Git API surgery to re-add protected branches/default branches/BR base branches.

We'll see if it actually works...