### PR TITLE
Release - v0.4.14

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -503,6 +503,10 @@ async function merge(options){
         await octokit.rest.git.updateRef({
             owner, repo, ref: `heads/${target}`, sha
         })
+
+        await octokit.rest.git.updateRef({
+            owner, repo, ref: `heads/${source}`, sha
+        })
     }
 
     // Create the tag
@@ -523,11 +527,11 @@ async function merge(options){
         // ,prerelease
     });
 
-    if( options.refresh || options['refresh-clean'] ){
-        await recreateSourceBranch({
-            ...options, clean: !!options['refresh-clean']
-        })
-    }
+    // if( options.refresh || options['refresh-clean'] ){
+    //     await recreateSourceBranch({
+    //         ...options, clean: !!options['refresh-clean']
+    //     })
+    // }
 }
 
 async function inferVersion({ owner, repo, lastRelease }){


### PR DESCRIPTION

# Release v0.4.14

<a name="changeSummary-start"></a>

- #78

<a name="changeSummary-end"></a>

## Changelog

<a name="changelog-start"></a>

### Major Changes

No major changes in this release.

### Minor Changes

No minor changes in this release.

### Patches

#### [Update source ref instead of creating source (@JAForbes)](https://github.com/JAForbes/pr-release/pull/78)

There is currently a fn `recreateSourceBranch`.  It ensures `next` is always in sync with `main` by recreating `next` post merge from `main`.

<a name="changelog-end"></a>

## Contributors


<a name="contributors-start"></a>

Thank you to the following contributors for helping make **pr-release** better:

- @JAForbes

<a name="contributors-end"></a>
        
        