### PR TITLE
Generate build artifacts on source branch at merge time.

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        ref: 'next'
     - run: npm ci
     - run: npm run build --if-present
     - run: node bin.js changelog --target main --source next --out changelog.md

--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ subcommands:
                         Commits updated changelog and creates new npm/github/etc release.
                         Should run on every relevant merge event.
 
+    --force
+
+                        Will repair the target branch if a fast forward update is not possible.  
+                        Otherwise will simply error that the branches have diverged or exit with
+                        code zero if everything is fine.
+
+    --clean
+
+                        By default --force will archive the old target branch under an alias.
+                        Use --clean to remove the archived old target branch once the process has
+                        completed successfully.
+
+
+  actions-yml
+
+                        Scaffold Github actions yml files
+
   feature-pr
 
                         Generate a feature-pr for the current branch that targets

--- a/lib/index.js
+++ b/lib/index.js
@@ -108,6 +108,7 @@ function verbose(...args){
 }
 
 function error(...args){
+    process.exitCode = 1
     console.error(...args)
 }
 
@@ -426,9 +427,20 @@ async function merge(options){
     // So we need to get the most recently merged release.
     // There may not be one, and if there is, there may already be a tag for that release
 
+
     let out = await extractChangelog({})
     let { version } = out
     let [owner,repo] = process.env.GITHUB_REPOSITORY.split('/')
+
+    let sourceSHA = 
+        await getSha({ owner, repo }, source)
+
+    let isAncestor = 
+        !await $`git fetch --all && git merge-base --is-ancestor ${`origin/${target}`} ${`origin/${source}`}`.exitCode
+
+    if (!isAncestor && !options.force) {
+        return error(`${source} is not an ancestor of ${target}.  Re-run with --force to enable a fast-forward release.`)
+    }
 
     let lastRelease = await getLastRelease({ owner, repo })
 
@@ -445,13 +457,12 @@ async function merge(options){
 
         if( found ) {
             info( 'Version tag', version, 'already exists, exiting with code zero.')
-            return;
+            return null;
         }
     }
 
     // eslint-disable-next-line no-unused-vars
-    let sha = process.env.GITHUB_SHA || await getSha({ owner, repo }, target)
-
+    
     // If there are some artifacts in the working tree
     // We should commit them to this release
     // We use the github API so we can make changes to
@@ -488,7 +499,7 @@ async function merge(options){
         changes = await Promise.all(changes)
 
         let base_tree = (
-            await octokit.rest.git.getRef({ owner, repo, ref: `heads/${target}` })
+            await octokit.rest.git.getRef({ owner, repo, ref: `heads/${source}` })
         )
         .data.object.sha
 
@@ -509,15 +520,27 @@ async function merge(options){
         })
 
         // eslint-disable-next-line no-unused-vars
-        sha = commit.data.sha
+        sourceSHA = commit.data.sha
 
         await octokit.rest.git.updateRef({
-            owner, repo, ref: `heads/${target}`, sha
+            owner, repo, ref: `heads/${source}`, sha: sourceSHA
         })
 
-        await octokit.rest.git.updateRef({
-            owner, repo, ref: `heads/${source}`, sha
-        })
+
+        // now we need to rewind target to just before the merge happened
+        // if, and only the merge was a squash or a rebase
+        // if, it was a normal merge commit/ff we can just update the ref
+        // of target to source
+        // so lets detect if it was a fast forward, we can just check the SHA
+        // of target, if it != originalSourceSHA
+
+        if (isAncestor){
+            await octokit.rest.git.updateRef({
+                owner, repo, ref: `heads/${target}`, sha: sourceSHA
+            })
+        } else {
+            await repairTarget({ force: options.force, clean: options.clean })
+        }
     }
 
     await octokit.rest.repos.createRelease({
@@ -531,6 +554,8 @@ async function merge(options){
         // ,draft
         // ,prerelease
     });
+
+    return null;
 }
 
 async function inferVersion({ owner, repo, lastRelease }){
@@ -1083,6 +1108,19 @@ subcommands:
 
                         Commits updated changelog and creates new npm/github/etc release.
                         Should run on every relevant merge event.
+
+    {blue --force}
+
+                        Will repair the target branch if a fast forward update is not possible.  
+                        Otherwise will simply error that the branches have diverged or exit with
+                        code zero if everything is fine.
+
+    {blue --clean}
+
+                        By default --force will archive the old target branch under an alias.
+                        Use --clean to remove the archived old target branch once the process has
+                        completed successfully.
+
 
   {magenta actions-yml}
 


### PR DESCRIPTION
Instead of generating build artifacts on the target branch and then adding them back to the source branch.  This change will run target's CI with source's ref.  We then generate build outputs on the source branch, and fast forward the target to the new commit that includes the artifacts.  Making both branches even.

If fast forwarding is not possible, we exit early and suggest running with `--force`.  Running with `--force` will recreate the target branch in the image of the source branch so that fast forwarding is possible.

The only time that should ever be required is if merging a release PR used squashing or creative rebasing.  Otherwise target and source should be in sync by default.

It is highly likely this will break once merged, in which case I'll fix in a patch release soon after.

Fixes #100