### PR TITLE
🚨 Rolled back changes: v0.7.8 to v0.7.8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,22 @@
 
+# Release v0.7.9
+
+Thank you to the following contributors for helping make **pr-release** better:
+
+- @JAForbes
+
+### Major Changes
+
+No major changes in this release.
+
+### Minor Changes
+
+No minor changes in this release.
+
+### Patches
+
+#### [Introduce change so I can test rollbacks (@JAForbes)](https://github.com/JAForbes/pr-release/pull/131)
+
 # Release v0.7.8
 
 Thank you to the following contributors for helping make **pr-release** better:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-release",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-release",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Generate releases from pull request descriptions.",
   "main": "dist/pr-release.cjs",
   "module": "lib/index.js",


### PR DESCRIPTION
This PR contains all changes after v0.7.8 through to the latest release v0.7.8.

These changes have been removed from next and main.  You can re-instate them by merging this PR.

However, this branch was likely rolled back for a reason.  You can use this branch to explore any reported bugs and fix them before re-instating these changes.

Because your next and main branches have been scrubbed clean of these changes you can continue to work on other unrelated change and release them while errors in this changeset are investigated.
