### PR TITLE
Reinstate rolled back changes: from v0.7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,8 @@ subcommands:
                         By default will archive the old target branch.  Use --clean
                         to remove the old target branch.
 ```
+
+
+### Rollback test
+
+This is a change I am going to release into production and then rollback.


### PR DESCRIPTION

This PR contains all changes after v0.7.8 through to the latest release v0.7.9.
    
These changes were previously removed from next and main.  You can re-instate them by merging this PR.
    
However, this branch was likely rolled back for a reason.  You can use this branch to explore any reported bugs and fix them before re-instating these changes.
    
Because your next and main branches have been scrubbed clean of these changes you can continue to work on other unrelated changes and release them
while errors in this changeset are investigated.
