### PR TITLE
Reinstate rolled back changes from v0.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,7 @@ I accidentally committed directly to `next`, this change will be a feature PR wh
 ### Another change for testing rollbacks
 
 Here we go....
+
+### Need some more changes
+
+I had some misconfigued yml templates so these changes can't be rolled back as it would rollback the yml fixes.  This change can be rolled back...

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,22 @@
 
+# Release v0.8.7
+
+Thank you to the following contributors for helping make **pr-release** better:
+
+- @JAForbes
+
+### Major Changes
+
+No major changes in this release.
+
+### Minor Changes
+
+No minor changes in this release.
+
+### Patches
+
+#### [Rollback test (@JAForbes)](https://github.com/JAForbes/pr-release/pull/157)
+
 # Release v0.8.6
 
 Thank you to the following contributors for helping make **pr-release** better:


### PR DESCRIPTION

This PR contains all changes after v0.8.6 through to the latest release v0.8.7.
    
These changes were previously removed from next and main.  You can re-instate them by merging this PR.
    
However, this branch was likely rolled back for a reason.  You can use this branch to explore any reported bugs and fix them before re-instating these changes.
    
Because your next and main branches have been scrubbed clean of these changes you can continue to work on other unrelated changes and release them
while errors in this changeset are investigated.
