### PR TITLE
Reinstate rolled back changes from v0.8.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,7 @@ Here we go....
 ### Need some more changes
 
 I had some misconfigued yml templates so these changes can't be rolled back as it would rollback the yml fixes.  This change can be rolled back...
+
+### Rollbacks seem to be working in CI
+
+But lets do a few more to be sure! 🚀🚀🚀


### PR DESCRIPTION

This PR contains all changes after v0.8.10 through to the latest release v0.8.11.

These changes were previously removed from next and main.  You can re-instate them by merging this PR.

However, this branch was likely rolled back for a reason.  You can use this branch to explore any reported bugs and fix them before re-instating these changes.

Because your next and main branches have been scrubbed clean of these changes you can continue to work on other unrelated changes and release them while errors in this changeset are investigated.
