### PR TITLE
Increment semver when committing directly to next

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -825,11 +825,16 @@ async function pr(){
     // todo-james
     let nextVersion; {
         nextVersion = semver.clean(version)
+        
         for(let level of ['patch', 'minor', 'major']){
             let n = severityIdx[level] ? severityIdx[level].length : 0
             for( let i = 0; i < n; i++ ) {
                 nextVersion = semver.inc(nextVersion, level)
             }
+        }
+
+        if ( semver.compare(nextVersion,version) == 0 ) {
+            nextVersion = semver.inc(nextVersion, 'patch')
         }
     }
 


### PR DESCRIPTION
Previously, if you edited some markdown files and committed directly to next, the auto generated release PR would have the same semver version as main.  This means on merge CI would fail.  This is no longer the case.  If the auto generated semver is the same as main, a patch change will be auto-incremented. 🏖