### PR TITLE
Handle the case where there is no prior release

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -9,8 +9,12 @@ description: Use Pull Requests to generate npm + github releases and changelogs
 
 ## Quick Start
 
-1. Run `npx pr-release actions-yml`
-2. Commit changes to your project and push
-3. Generate a [Personal Access Token](/env/#personal-access-token) and [NPM token](/env/#npm-token)
-4. Add them to your [project's environment settings](/env/#environment-settings)
-5. You now have an automated release pipeline
+
+1. Create a branch called `next` and set it as the default branch for the repo
+2. Create a branch called `main`
+3. Make both `next` and `main` protected branches
+4. Run `npx pr-release actions-yml`
+5. Commit changes to your project and push to `next`, then merge `next` into `main`
+6. Generate a [Personal Access Token](/env/#personal-access-token) and [NPM token](/env/#npm-token)
+7. Add them to your [project's environment settings](/env/#environment-settings)
+8. You now have an automated release pipeline

--- a/lib/index.js
+++ b/lib/index.js
@@ -305,14 +305,24 @@ async function extractChangelog(options){
         b = _b
     }
 
-    let recentBranches = 
-        await octokit.paginate(octokit.rest.search.issuesAndPullRequests, {
-            q: `merged:${a.closed_at}..${b.closed_at} base:${source} is:pr is:merged repo:${owner}/${repo}`
-            ,sort: 'updated'
-            ,order: 'desc'
-            ,per_page: 2
-            ,page: 1
-        })
+
+    let recentBranches; {
+
+        let firstEverRelease = a == null;
+
+        let q = firstEverRelease
+            ? `base:${source} is:pr is:merged repo:${owner}/${repo}`
+            : `merged:${a.closed_at}..${b.closed_at} base:${source} is:pr is:merged repo:${owner}/${repo}`
+
+        recentBranches = 
+            await octokit.paginate(octokit.rest.search.issuesAndPullRequests, {
+                q
+                ,sort: 'updated'
+                ,order: 'desc'
+                ,per_page: 2
+                ,page: 1
+            })
+    } 
     
     let openBranches = 
         await getRecentBranches({ owner, repo, lastRelease })


### PR DESCRIPTION
When identifying which branches belong to a release, we construct a github search query which finds branches dated after the previous release.

If there was no previous release, it crashes.  This PR should fix that.