### PR TITLE
Allow failures when publishing prerelease

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -406,6 +406,8 @@ async function extractChangelog(options){
     let { version } = 
         await inferVersion({ owner, repo, lastRelease })
 
+    // this version is the published version + branch inferred versions
+    // it ignores the version set in the PR description
     let nextVersion = 
         await getNextVersion({ recentBranches: openBranches, version })
 
@@ -503,7 +505,7 @@ async function extractChangelog(options){
     return out
 }
 
-async function getLastRelease({ owner, repo }){
+async function getLastRelease({ owner, repo, merged=true }){
     let lastRelease;
     lastRelease = await octokit.rest.search.issuesAndPullRequests({
         q: `is:pr is:merged base:${target} head:${source} repo:${owner}/${repo}`


### PR DESCRIPTION
Maybe that version, or CI job already ran.