### PR TITLE
Globally install wrangler in CI

### DIFF
--- a/run.js
+++ b/run.js
@@ -17,6 +17,7 @@ async function watch(){
 async function deploy(){
     await $`node -r dotenv/config bin.js extract-changelog --out`
     await $`node scripts/build-docs.js`
+    await $`npm install @cloudflare/wrangler -g`
     await $`npx @cloudflare/wrangler publish`
 }
 


### PR DESCRIPTION
Got a strange error when publishing the docs

`npx @cloudflare/wrangler publish` errors out with `You have not installed wrangler`.

I'm not sure what is going on, but this PR simply installs wrangler globally prior to publishing.