### PR TITLE
Safely generate prerelease semver id and publish

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,13 +29,10 @@ jobs:
     - run: node bin.js pr --verbose --target main --source next --compact --verbose
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-# The following will publish a pre-release to npm
-    - run: node bin.js extract-changelog --target main --source next --compact --out                       # prr:comment
-    - run: npm version --no-verify --no-commit-hooks --no-git-tag-version $(cat ./.pr-release/nextVersion) # prr:comment
-    - run: npm version --no-verify --no-commit-hooks --no-git-tag-version prerelease --preid=next          # prr:comment
+    # The following will publish a prerelease to npm
     - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc                                   # prr:comment
       name: Setup NPM Auth                                                                                 # prr:comment
       env:                                                                                                 # prr:comment
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}                                                                # prr:comment
-    - run: npm publish --tag=next                                                                          # prr:comment
+    - run: node bin.js infer-prerelease --preid=next --verbose --publish                                   # prr:comment
       name: Publish                                                                                        # prr:comment

--- a/lib/index.js
+++ b/lib/index.js
@@ -1599,6 +1599,76 @@ async function updateRef(options, branch=options.branch, sha=options.sha){
     })
 }
 
+// Can't rely on just npm info because GITHUB_REPOSITORY
+// is the source of truth, not the cwd.
+async function inferPreReleaseExternal({ 
+    preid='next'
+    , 'package-path': packagePath='package.json'
+    , publish=false
+    , apply=publish
+}={}){
+
+    let [owner,repo] = process.env.GITHUB_REPOSITORY.split('/')
+
+    let x = await octokit.rest.repos.getContent({
+        owner, repo, path: packagePath
+    })
+    x = x.data.content
+    x = Buffer.from(x, 'base64').toString()
+    x = JSON.parse(x)
+
+    x = (await $`npm info ${x.name} --json`).stdout
+    x = JSON.parse(x)
+
+    x = x['dist-tags']
+    x = x[preid]
+
+    let existingPreReleaseVersion = x
+
+    let lastRelease = await getLastRelease({ owner, repo })
+    
+    let openBranches = 
+        lastRelease
+        ? await getRecentBranches({ owner, repo, lastRelease })
+        : []
+
+    let { version } = 
+        await inferVersion({ owner, repo, lastRelease })
+
+    let nextVersion = 
+        await getNextVersion({ recentBranches: openBranches, version })
+
+    
+    if(!semver.prerelease(nextVersion)){
+        x = nextVersion+'-'+preid+'.0'
+    } else {
+        x = semver.inc(nextVersion, 'prerelease')
+    }
+
+    if ( existingPreReleaseVersion ) {
+        if( semver.compare(x,existingPreReleaseVersion) == 0) {
+            verbose('prerelease version already exists incrementing...')
+            x=semver.inc(x, 'prerelease')
+        } else if (semver.compare(x,existingPreReleaseVersion) == -1) {
+            verbose('prerelease version is < an existing prerelease version')
+            verbose('using published prerelease version as base...')
+            x = semver.inc(existingPreReleaseVersion, 'prerelease')
+        }
+    }
+    
+    if ( apply ) {
+        await $`npm version ${x} --no-verify --no-commit-hooks --no-git-tag-version`
+    }
+    if (publish) {
+        let tag = typeof publish == 'string' ? publish : preid
+        await $`npm publish --tag=${tag}`
+    }
+
+    if(!apply) {
+        console.log(x)
+    }
+}
+
 let help = ({ green, blue, magenta, red }) => 
 `${green(`pr-release`)} 
 
@@ -1721,6 +1791,32 @@ subcommands:
                         By default will archive the old target branch.  Use --clean
                         to remove the old target branch.
 
+${magenta(`infer-prerelease`)}
+
+                        Outputs the version pr-release estimates the next release should be.
+                        This is the same function used to generate the versions in the title
+                        header and body but as a standalone command.
+
+
+    ${blue(`--preid=next`)}
+
+                        Specifies the prerelease format, e.g. --preid=alpha results in v1.0.0-alpha.0
+
+    ${blue(`--package-path=package.json`)}
+
+                        To support monorepos that have package.json at child directory paths
+
+    ${blue(`--apply`)}
+
+                        Applies inferred version to package.json in CI, to enable publishing.
+
+    ${blue(`--publish=<tag>`)}
+
+                        Publish the prerelease version to npm (implies --apply)
+
+                        ${blue(`--publish`)} will publish to the same release channel as preid (defaults to next)
+
+                        ${blue(`--publish=alpha`)} will publish to the specified channel, in this case alpha
 `
 
 let [subcommand] = argv._
@@ -1738,6 +1834,7 @@ let subcommands = {
     , 'generate-templates': generateTemplates
     , 'update-docs': updateDocs
     , 'infer-version': inferVersionExternal
+    , 'infer-prerelease': inferPreReleaseExternal
 }
 
 let preflights = {
@@ -1750,6 +1847,7 @@ let preflights = {
     , rollback
     , 'update-ref': updateRef
     , 'infer-version': inferVersionExternal
+    , 'infer-prerelease': inferPreReleaseExternal
 }
 
 

--- a/templates/pr.yml
+++ b/templates/pr.yml
@@ -29,13 +29,10 @@ jobs:
     - run: npx pr-release pr --verbose --target $target --source $source --compact --verbose
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-# The following will publish a pre-release to npm
-#    - run: npx pr-release extract-changelog --target $target --source $source --compact --out                       
-#    - run: npm version --no-verify --no-commit-hooks --no-git-tag-version $(cat ./.pr-release/nextVersion) 
-#    - run: npm version --no-verify --no-commit-hooks --no-git-tag-version prerelease --preid=$source          
+    # The following will publish a prerelease to npm
 #    - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc                                   
 #      name: Setup NPM Auth                                                                                 
 #      env:                                                                                                 
 #        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}                                                                
-#    - run: npm publish --tag=$source                                                                          
+#    - run: npx pr-release infer-prerelease --preid=$source --verbose --publish                                   
 #      name: Publish                                                                                        


### PR DESCRIPTION
- Handle a preid already being published
- Handle no existing version of that preid
- Handle the existing version being > than the proposed version
- Optionally apply/publish