### PR TITLE
Handle merge case where no prior release PR exists, but commit history exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -295,44 +295,14 @@ async function actionsYML(){
  */
 async function extractChangelog(options){
     let [owner,repo] = process.env.GITHUB_REPOSITORY.split('/')
-    let lastRelease = await getLastRelease({ owner, repo })
 
-    let a,b; {
-        let r = await octokit.rest.search.issuesAndPullRequests({
-            q: `is:pr is:merged base:${target} head:${source} repo:${owner}/${repo}`
-            ,sort: 'updated'
-            ,order: 'desc'
-            ,per_page: 2
-            ,page: 1
+    // The PR to use to generate the next changelog entry
+    const lastRelease = await getLastRelease({ owner, repo })
+
+    let recentBranches = 
+        await getRecentBranchesFromPRCommitHistory({ 
+            owner, repo, pull_number: lastRelease.number
         })
-
-        r = r.data.items
-        r = r.sort( (a,b) => a.number - b.number )
-
-        let [_a,_b] = r
-        a = _a
-        b = _b
-    }
-
-
-    let recentBranches; {
-
-        let firstEverRelease = a == null;
-        let onlyOneRelease = b == null
-
-        let q = firstEverRelease || onlyOneRelease
-            ? `base:${source} is:pr is:merged repo:${owner}/${repo}`
-            : `merged:${a.closed_at}..${b.closed_at} base:${source} is:pr is:merged repo:${owner}/${repo}`
-
-        recentBranches = 
-            await octokit.paginate(octokit.rest.search.issuesAndPullRequests, {
-                q
-                ,sort: 'updated'
-                ,order: 'desc'
-                ,per_page: 2
-                ,page: 1
-            })
-    }
 
     let lines = 
         lastRelease
@@ -385,7 +355,7 @@ async function extractChangelog(options){
             mode = 'major'; continue;
         } else if ( line == '### Minor Changes' ) {
             mode = 'minor'; continue;
-        } else if ( line == '### Patches' ) {
+        } else if ( line == '### Patch Changes' ) {
             mode = 'patch'; continue;
         } else {
             sections[mode].push(line)
@@ -397,7 +367,7 @@ async function extractChangelog(options){
     let patch = sections.patch.join('\n').trim()
 
     let { version } = 
-        await inferVersion({ owner, repo, lastRelease })
+        await inferVersion({ owner, repo })
 
     // this version is the published version + branch inferred versions
     // it ignores the version set in the PR description
@@ -526,6 +496,53 @@ async function getThisRelease({ owner, repo }){
     return thisRelease
 }
 
+/**
+ * Identifies the feature branch PRs from a given
+ * release PRs commit history.
+ * 
+ * Much more accurate than relying on merged_at timestamps.
+ * 
+ * `pr` cannot use this because we create the pull request
+ * after we've generated the changelog.  But it might be
+ * worth creating an empty PR first just to unify that logic
+ * and make the code a bit less temporal.
+ */
+async function getRecentBranchesFromPRCommitHistory({ 
+    owner, repo, pull_number 
+}){
+
+    const pullCommits = 
+        await octokit.paginate(
+            octokit.rest.pulls.listCommits
+            , { owner, repo, pull_number }
+        )
+
+    let recentBranches = await Promise.all(
+        pullCommits.map( x => 
+
+            octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner
+                , repo
+                , commit_sha: x.sha
+            })    
+            .then( ({ data: [x] }) => x ? [x] : [] )
+        )
+    )
+    .then( xs => xs.flat().filter( x => x.base.ref === source ) )
+
+    {
+        let seen = new Set()
+        recentBranches = recentBranches.filter( x => {
+            if( seen.has( x.number) ) return false;
+            seen.add(x.number)
+            return true;
+        })
+    }
+
+    return recentBranches;
+}
+
+
 async function getRecentBranchesFromLastRelease({ owner, repo, lastRelease }){
     return getRecentBranchesFromLastCommitDate({ 
         owner
@@ -574,7 +591,7 @@ async function merge(options){
     const changelogOut = typeof options.changelog == 'string' ? { out: options.changelog } : {}
 
     let out = options.changelog 
-        ? await changelog({ ...changelogOut })
+        ? await externalChangelog({ ...changelogOut })
         : await extractChangelog({})
 
     let { nextVersion } = out
@@ -1200,7 +1217,7 @@ async function pr(options){
     }
 }
 
-async function changelog(options){
+async function externalChangelog(options){
     let x = await extractChangelog({})
 
     if( x.changelog + x.changeSummary + x.contributorsBody == '' ) {
@@ -1863,7 +1880,7 @@ let subcommands = {
     , merge
     , 'actions-yml': actionsYML
     , 'extract-changelog': extractChangelog
-    , changelog
+    , changelog: externalChangelog
     , 'feature-pr': featurePR
     , 'repair-target': repairTarget
     , rollback
@@ -1878,7 +1895,7 @@ let preflights = {
     pr
     , merge
     , 'extract-changelog': extractChangelog
-    , changelog
+    , changelog: externalChangelog
     , 'feature-pr': featurePR
     , 'repair-target': repairTarget
     , rollback


### PR DESCRIPTION
Fixes #323

I've reworked the code to be a bit less temporal.  Instead of relying on upper and lower data bounds by querying for prior/latter PRs to identify which feature branches belong to a release, I'm using a fairly obscure octokit method:

`listPullRequestsAssociatedWithCommit`

This allows me to get the PRs associated with every commit associated with a given PR.  I can then test the `extractChangelog` without having to actually merge a release PR.

I'd like to make `pr` use this as well, but that would involve creating the PR at the start of the function instead of at the end.  Previously I was trying to make mutative API calls at the end of the job so if there was an early crash the repo wouldn't be left with unfinished state.  But I think its worth reworking that.

