### PR TITLE
Release - v0.18.18

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -73,7 +73,7 @@ If `GITHUB_SHA` is not specified, `pr-release` will make an API call to identify
 
 pr-release automatically ensures that post a merge of a release branch that `main` is an exact copy of `next`.
 
-In git parlance, pr-release guarantees that `main` has the same ref and history as main by ensuring the merge of `next` into `main` is a fast forward.
+In git parlance, pr-release guarantees that `main` has the same ref and history as `next` by ensuring the merge of `next` into `main` is a fast forward.
 
 This way, if changes are applied to the `next` branch, such as versioning, or generating changelogs, they always appear on the branch that represents "production".
 


### PR DESCRIPTION

# Release v0.18.18

<a name="changeSummary-start"></a>

- #344

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Patch Changes

#### [Fix a typo (@pygy)](https://github.com/JAForbes/pr-release/pull/344)

> *pr-release guarantees that `main` has the same ref and history as ~~main~~`next`*.
   
<a name="changelog-end"></a>
           
        